### PR TITLE
Add $manage_user, $gerrit_user,  and $gerrit_group parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ gerrit::extra_configs:
         remoteNameStyle: 'dash'
 ```
 
+#### `gerrit_group`
+
+The primary group of the gerrit user. Default value: gerrit
+
 #### `gerrit_home`
 
 The home directory for the gerrit user / installation path. Default
@@ -241,6 +245,10 @@ gerrit_site_options       => {
 If an option is not present then the default "blank" file will be used.
 
 This hash is only used if `manage_site_skin` is true (default)
+
+#### `gerrit_user`
+
+The user that Gerrit runs as. Default gerrit
 
 #### `gerrit_version`
 
@@ -306,6 +314,11 @@ setting: false
 
 If true then `static_source` (see below) is required.
 
+#### `manage_user`
+
+Should this module create the gerrit_user and gerrit_group (true) or
+will they be managed elsewhere (false)? Default setting: true
+
 #### `override_options`
 
 A variable hash for configuration settings of Gerrit. These options are
@@ -318,7 +331,6 @@ default_options => {
     'type'      => 'OpenID',
   },
   'container'   => {
-    'user'      => 'gerrit',
     'javaHome'  => '/usr/lib/jvm/jre',
   },
   'gerrit'      => {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -103,7 +103,9 @@ class gerrit::config (
   $db_tag,
   $default_secure_options,
   $extra_configs,
+  $gerrit_group,
   $gerrit_home,
+  $gerrit_user,
   $manage_database,
   $manage_firewall,
   $options,
@@ -112,14 +114,13 @@ class gerrit::config (
   validate_string($db_tag)
   validate_hash($default_secure_options)
   validate_hash($extra_configs)
+  validate_string($gerrit_group)
   validate_absolute_path($gerrit_home)
+  validate_string($gerrit_user)
   validate_bool($manage_database)
   validate_bool($manage_firewall)
   validate_hash($options)
   validate_hash($override_secure_options)
-
-  $gerrit_user = $options['container']['user']
-  validate_string($gerrit_user)
 
   anchor { 'gerrit::config::begin': }
   anchor { 'gerrit::config::end': }
@@ -130,7 +131,7 @@ class gerrit::config (
     ensure  => file,
     path    => '/etc/default/gerritcodereview',
     owner   => $gerrit_user,
-    group   => $gerrit_user,
+    group   => $gerrit_group,
     mode    => '0644',
     content => template('gerrit/gerrit_defaults.erb'),
   }

--- a/manifests/config/git_config.pp
+++ b/manifests/config/git_config.pp
@@ -59,12 +59,13 @@ define gerrit::config::git_config (
 file modes.")
   validate_hash($options)
 
+  $gerrit_group = $gerrit::config::gerrit_group
   $gerrit_user = $gerrit::config::gerrit_user
 
   file { $config_file:
     ensure  => file,
     owner   => $gerrit_user,
-    group   => $gerrit_user,
+    group   => $gerrit_group,
     mode    => $mode,
     content => template('gerrit/git.ini.erb'),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,9 @@
 #     },
 #   }
 #
+# [*gerrit_group*]
+#   The primary group or gid of the gerrit user. Default is 'gerrit'
+#
 # [*gerrit_home*]
 #   The home directory for the gerrit user / installation path
 #
@@ -85,6 +88,9 @@
 #   used.
 #
 #   This hash is only used if manage_site_skin is true (default)
+#
+# [*gerrit_user*]
+#   The user that Gerrit runs as. Default is 'gerrit'
 #
 # [*gerrit_version*]
 #   The version of the Gerrit war that will be downloaded
@@ -132,6 +138,10 @@
 #   Should the ~gerrit/static structure be managed by the module.  If
 #   true then static_source must be set.
 #   default false
+#
+# [*manage_user*]
+#   Should the creation of the Gerrit $user be managed by the module.
+#   default true
 #
 # [*override_options*]
 #   A variable hash for configuration settings of Gerrit. Please see
@@ -202,8 +212,10 @@ class gerrit (
   $db_tag                   = '',
   $download_location        = $gerrit::params::download_location,
   $extra_configs            = {},
+  $gerrit_group             = $gerrit::params::gerrit_group,
   $gerrit_home              = $gerrit::params::gerrit_home,
   $gerrit_site_options      = {},
+  $gerrit_user              = $gerrit::params::gerrit_user,
   $gerrit_version           = $gerrit::params::gerrit_version,
   $install_default_plugins  = $gerrit::params::install_default_plugins,
   $install_git              = $gerrit::params::install_git,
@@ -213,6 +225,7 @@ class gerrit (
   $manage_firewall          = $gerrit::params::manage_firewall,
   $manage_site_skin         = $gerrit::params::manage_site_skin,
   $manage_static_site       = $gerrit::params::manage_static_site,
+  $manage_user              = $gerrit::params::manage_user,
   $override_options         = {},
   $override_secure_options  = {},
   $plugin_list              = $gerrit::params::plugin_list,
@@ -226,8 +239,10 @@ class gerrit (
   validate_string($db_tag)
   validate_string($download_location)
   validate_hash($extra_configs)
+  validate_string($gerrit_group)
   validate_absolute_path($gerrit_home)
   validate_hash($gerrit_site_options)
+  validate_string($gerrit_user)
   validate_string($gerrit_version)
   validate_bool($install_default_plugins)
   validate_bool($install_git)
@@ -236,6 +251,7 @@ class gerrit (
   validate_bool($manage_database)
   validate_bool($manage_site_skin)
   validate_bool($manage_static_site)
+  validate_bool($manage_user)
   validate_hash($override_options)
   validate_hash($override_secure_options)
   validate_array($plugin_list)
@@ -260,8 +276,10 @@ Allowed values are true, false, 'manual'.")
 
   class { '::gerrit::install':
     download_location       => $download_location,
+    gerrit_group            => $gerrit_group,
     gerrit_home             => $gerrit_home,
     gerrit_site_options     => $gerrit_site_options,
+    gerrit_user             => $gerrit_user,
     gerrit_version          => $gerrit_version,
     install_default_plugins => $install_default_plugins,
     install_java            => $install_java,
@@ -269,6 +287,7 @@ Allowed values are true, false, 'manual'.")
     install_gitweb          => $install_gitweb,
     manage_site_skin        => $manage_site_skin,
     manage_static_site      => $manage_static_site,
+    manage_user             => $manage_user,
     options                 => $options,
     plugin_list             => $plugin_list,
     static_source           => $static_source,
@@ -279,7 +298,9 @@ Allowed values are true, false, 'manual'.")
     db_tag                  => $db_tag,
     default_secure_options  => $gerrit::params::default_secure_options,
     extra_configs           => $extra_configs,
+    gerrit_group            => $gerrit_group,
     gerrit_home             => $gerrit_home,
+    gerrit_user             => $gerrit_user,
     manage_database         => $manage_database,
     manage_firewall         => $manage_firewall,
     options                 => $options,
@@ -287,7 +308,9 @@ Allowed values are true, false, 'manual'.")
   }
 
   class { '::gerrit::initialize':
+    gerrit_group   => $gerrit_group,
     gerrit_home    => $gerrit_home,
+    gerrit_user    => $gerrit_user,
     gerrit_version => $gerrit_version,
     options        => $options,
   }

--- a/manifests/initialize.pp
+++ b/manifests/initialize.pp
@@ -11,8 +11,14 @@
 #
 # The following variables are required
 #
+# [*gerrit_group*]
+#   The primary group of the gerrit user
+#
 # [*gerrit_home*]
 #   The home directory for the gerrit user / installation path
+#
+# [*gerrit_user*]
+#   The user that gerrit runs as
 #
 # [*gerrit_version*]
 #   The version of the Gerrit war that will be downloaded
@@ -32,16 +38,17 @@
 # Copyright 2014 Andrew Grimberg
 #
 class gerrit::initialize (
+  $gerrit_group,
   $gerrit_home,
+  $gerrit_user,
   $gerrit_version,
   $options
 ) {
+  validate_string($gerrit_group)
   validate_string($gerrit_home)
+  validate_string($gerrit_user)
   validate_string($gerrit_version)
   validate_hash($options)
-
-  $gerrit_user      = $options['container']['user']
-  validate_string($gerrit_user)
 
   $gerrit_basepath  = $options['gerrit']['basePath']
   validate_absolute_path($gerrit_basepath)
@@ -53,6 +60,7 @@ class gerrit::initialize (
 init -d ${gerrit_home} --batch && java -jar \
 ${gerrit_home}/bin/gerrit.war reindex -d ${gerrit_home}",
     creates => "${gerrit_basepath}/All-Projects.git/HEAD",
+    group   => $gerrit_group,
     user    => $gerrit_user,
   }
 }

--- a/manifests/install/plugin_files.pp
+++ b/manifests/install/plugin_files.pp
@@ -1,16 +1,18 @@
 define gerrit::install::plugin_files (
+  $gerrit_group,
   $gerrit_home,
   $gerrit_user
 ) {
+  validate_string($gerrit_group)
   validate_absolute_path($gerrit_home)
   validate_string($gerrit_user)
 
   file { $name:
     ensure => file,
+    group  => $gerrit_group,
+    owner  => $gerrit_user,
     path   => "${gerrit_home}/plugins/${name}.jar",
     source =>
       "${gerrit_home}/extract_plugins/WEB-INF/plugins/${name}.jar",
-    owner  => $gerrit_user,
-    group  => $gerrit_user,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,11 +8,14 @@
 #   The authentication type that gerrit should use. Default OpenID. See
 #   the Gerrit documentation for valid types
 #
-# [*user*]
-#   The user that Gerrit runs as
-#
 # [*basepath*]
 #   The base location where Gerrit will store the git repositories
+#
+# [*gerrit_group*]
+#   The primary group or gid of the Gerrit user
+#
+# [*gerrit_user*]
+#   The user that Gerrit runs as
 #
 # [*gerrit_version*]
 #   The version of Gerrit to download
@@ -60,6 +63,9 @@
 #
 # [*manage_static_site*]
 #   Should we manage the contents of ${gerrit_home}/static?
+#
+# [*manage_user*]
+#   Should we manage the creation of the Gerrit user?
 #
 # [*refresh_service*]
 #   Should the gerrit service be refreshed on changes to gerrit.config
@@ -112,7 +118,8 @@ class gerrit::params {
   $auth_type           = 'OpenID'
 
   # gerrit base information
-  $user               = 'gerrit'
+  $gerrit_user        = 'gerrit'
+  $gerrit_group       = 'gerrit'
   $basepath           = '/srv/gerrit'
 
   # default gerrit download information
@@ -132,6 +139,7 @@ class gerrit::params {
   $manage_firewall         = true
   $manage_site_skin        = true
   $manage_static_site      = false
+  $manage_user             = true
   $refresh_service         = true
   $service_enabled         = true
 
@@ -141,7 +149,6 @@ class gerrit::params {
       'type'    => $gerrit::params::auth_type,
     },
     'container'  => {
-      'user'     => $gerrit::params::user,
       'javaHome' => $gerrit::params::java_home,
     },
     'gerrit'     => {

--- a/spec/classes/config__firewall_spec.rb
+++ b/spec/classes/config__firewall_spec.rb
@@ -13,7 +13,7 @@ describe 'gerrit::config::firewall', :type => :class do
     end
   end
 
-  # with the 'assumed' relavent defaults fall through from a basic
+  # with the 'assumed' relevant defaults fall through from a basic
   # include ::gerrit
   context 'with assumed default parameters' do
     let(:params) {

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -33,7 +33,9 @@ describe 'gerrit::config', :type => :class do
           },
         },
         'extra_configs'               => {},
+        'gerrit_group'                => 'gerritgroup',
         'gerrit_home'                 => '/opt/gerrit',
+        'gerrit_user'                 => 'gerrituser',
         'manage_database'             => true,
         'manage_firewall'             => true,
         'options'                     => {
@@ -41,7 +43,6 @@ describe 'gerrit::config', :type => :class do
             'type'                    => 'OpenID',
           },
           'container'                 => {
-            'user'                    => 'gerrit',
             'javaHome'                => '/usr/lib/jvm/jre',
           },
           'gerrit'                    => {
@@ -57,14 +58,14 @@ describe 'gerrit::config', :type => :class do
 
     it { is_expected.to contain_file('/opt/gerrit/etc/gerrit.config').with(
         'ensure'  => 'file',
-        'owner'   => 'gerrit',
-        'group'   => 'gerrit',
+        'owner'   => 'gerrituser',
+        'group'   => 'gerritgroup',
         'mode'    => '0660',
         ) }
     it { is_expected.to contain_file('/opt/gerrit/etc/secure.config').with(
         'ensure'  => 'file',
-        'owner'   => 'gerrit',
-        'group'   => 'gerrit',
+        'owner'   => 'gerrituser',
+        'group'   => 'gerritgroup',
         'mode'    => '0600',
         'content' => "; MANAGED BY PUPPET\n\n[auth]\n\tregisterEmailPrivateKey = Hf8yvvCrs6dDBEc6WczhlEJD7rJGOHe7hr\n\trestTokenPrivateKey = 39v9y20F3nCQglWvDXFIXMCy9qORHWwxTO\n\n",
         ) }
@@ -74,8 +75,8 @@ describe 'gerrit::config', :type => :class do
         ) }
     it { is_expected.to contain_file('gerrit_defaults').with(
         'ensure'  => 'file',
-        'owner'   => 'gerrit',
-        'group'   => 'gerrit',
+        'owner'   => 'gerrituser',
+        'group'   => 'gerritgroup',
         'mode'    => '0644',
         'content' => "GERRIT_SITE=/opt/gerrit\n",
         ) }
@@ -93,7 +94,9 @@ describe 'gerrit::config', :type => :class do
           },
         },
         'extra_configs'               => {},
+        'gerrit_group'                => 'gerritgroup',
         'gerrit_home'                 => '/opt/gerrit',
+        'gerrit_user'                 => 'gerrituser',
         'manage_database'             => true,
         'manage_firewall'             => true,
         'options'                     => {
@@ -101,7 +104,6 @@ describe 'gerrit::config', :type => :class do
             'type'                    => 'OpenID',
           },
           'container'                 => {
-            'user'                    => 'gerrit',
             'javaHome'                => '/usr/lib/jvm/jre',
           },
           'gerrit'                    => {
@@ -161,7 +163,9 @@ describe 'gerrit::config', :type => :class do
             },
           },
         },
+        'gerrit_group'                => 'gerritgroup',
         'gerrit_home'                 => '/opt/gerrit',
+        'gerrit_user'                 => 'gerrituser',
         'manage_database'             => true,
         'manage_firewall'             => true,
         'options'                     => {
@@ -169,7 +173,6 @@ describe 'gerrit::config', :type => :class do
             'type'                    => 'OpenID',
           },
           'container'                 => {
-            'user'                    => 'gerrit',
             'javaHome'                => '/usr/lib/jvm/jre',
           },
           'gerrit'                    => {

--- a/spec/classes/initialize_spec.rb
+++ b/spec/classes/initialize_spec.rb
@@ -5,14 +5,15 @@ describe 'gerrit::initialize', :type => :class do
   # testing
   let(:params) {
     {
+      'gerrit_group'      => 'gerritgroup',
       'gerrit_home'       => '/opt/gerrit',
+      'gerrit_user'       => 'gerrituser',
       'gerrit_version'    => '2.9.3',
       'options'           => {
         'auth'            => {
           'type'          => 'OpenID',
         },
         'container'       => {
-          'user'          => 'gerrit',
           'javaHome'      => '/usr/lib/jvm/jre',
         },
         'gerrit'          => {
@@ -44,7 +45,7 @@ describe 'gerrit::initialize', :type => :class do
       'command' => 'java -jar /opt/gerrit/bin/gerrit-2.9.3.war init -d /opt/gerrit --batch && java -jar /opt/gerrit/bin/gerrit.war reindex -d /opt/gerrit',
       'creates' => '/srv/gerrit/All-Projects.git/HEAD',
       'path'    => [ '/usr/bin', '/usr/sbin' ],
-      'user'    => 'gerrit',
+      'user'    => 'gerrituser',
     ) }
   end
 end

--- a/spec/defines/install__plugin_files_spec.rb
+++ b/spec/defines/install__plugin_files_spec.rb
@@ -5,18 +5,19 @@ describe 'gerrit::install::plugin_files', :type => :define do
 
   let(:params) {
     {
-      'gerrit_home' => '/opt/gerrit',
-      'gerrit_user' => 'gerrit',
+      'gerrit_group' => 'gerritgroup',
+      'gerrit_home'  => '/opt/gerrit',
+      'gerrit_user'  => 'gerrituser',
     }
   }
 
   context 'good params' do
     it { is_expected.to contain_file('testplugin').with(
       'ensure' => 'file',
+      'group'  => 'gerritgroup',
+      'owner'  => 'gerrituser',
       'path'   => '/opt/gerrit/plugins/testplugin.jar',
       'source' => '/opt/gerrit/extract_plugins/WEB-INF/plugins/testplugin.jar',
-      'owner'  => 'gerrit',
-      'group'  => 'gerrit',
     ) }
   end
 

--- a/templates/gerrit.service.erb
+++ b/templates/gerrit.service.erb
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/default/gerritcodereview
 SyslogIdentifier=gerrit
 ExecStart=/usr/bin/java $JAVA_OPTIONS -jar <%= @gerrit_home %>/bin/gerrit.war daemon -d $GERRIT_SITE
 User=<%= @gerrit_user %>
-Group=<%= @gerrit_user %>
+Group=<%= @gerrit_group %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Allow external management of the gerrit user.  Also, do not assume that the gerrit group and gerrit user are the same name.