### PR TITLE
Add Debian support for >= jessie releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['< 4.3.0', '>= 3.3']
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
-gem 'puppet-lint', '>= 0.3.2'
+gem 'puppet-lint', '< 2.0.0', '>= 0.3.2'
 gem 'facter', '>= 1.7.0'
 gem 'rspec'
 gem 'rspec-puppet'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@
 [![Build Status](https://travis-ci.org/tykeal/puppet-gerrit.png)](https://travis-ci.org/tykeal/puppet-gerrit)
 
 This module installs and configures a Gerrit system. It is intended to
-work with Puppet >= v3.7 as that is what it is developed against.
+work with Puppet >= v3.7, =< v.4.2.3 as that is what it is developed
+against.
+For newer puppet versions there is no complete rspec tests coverage
+for now but it may still work.
 
 ## Module Description
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -199,6 +199,7 @@ class gerrit::install (
         'Fedora': {
           if versioncmp($::operatingsystemrelease, '14') >= 0 {
             $use_systemd = true
+            $systemd_path = '/usr/lib/systemd/system'
           } else {
             $use_systemd = false
           }
@@ -207,13 +208,23 @@ class gerrit::install (
         default: {
           if versioncmp($::operatingsystemrelease, '7.0') >= 0 {
             $use_systemd = true
+            $systemd_path = '/usr/lib/systemd/system'
           } else {
             $use_systemd = false
           }
         }
       }
     }
-    # We don't currently support not RH based systems
+    'Debian': {
+      if versioncmp($::operatingsystemrelease, '8') >= 0 {
+        $use_systemd = true
+        $systemd_path = '/lib/systemd/system'
+      }
+      else {
+        fail("${::osfamily} is supported for versions >= 8 (>= jessie)")
+      }
+    }
+    # We don't currently support not RH/Debian based systems
     default: {
       fail("${::osfamily} is not presently supported")
     }
@@ -242,7 +253,7 @@ class gerrit::install (
 
     file { 'gerrit_systemd_script':
       ensure  => file,
-      path    => '/usr/lib/systemd/system/gerrit.service',
+      path    => "${systemd_path}/gerrit.service",
       owner   => 'root',
       group   => 'root',
       mode    => '0644',


### PR DESCRIPTION
The module was tested on jessie and it worked just fine with small changes suggested in this request
